### PR TITLE
implement backend and frontend timeouts

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -43,7 +43,8 @@ impl Config {
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // get db file
     let config = Config::build(env::args())
         .unwrap_or_else(|err| panic!("Problem parsing arguments: {:?}", err));
@@ -89,7 +90,8 @@ fn main() {
     println!("{}", ["#"; 20].concat());
     println!("Calculating shortest path...");
     println!("{}", ["#"; 20].concat());
-    let shortest_path = shortest_path(source_actor, target_actor, &db);
+    let shortest_path = shortest_path(source_actor, target_actor, &db).await;
+
 
     match shortest_path {
         Ok(path) => {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -92,7 +92,6 @@ async fn main() {
     println!("{}", ["#"; 20].concat());
     let shortest_path = shortest_path(source_actor, target_actor, &db).await;
 
-
     match shortest_path {
         Ok(path) => {
             println!("Degrees of connection: {}", path.len() - 1);

--- a/src/webapp/routes/shortest_path.rs
+++ b/src/webapp/routes/shortest_path.rs
@@ -14,8 +14,6 @@ pub struct Connection {
     actor_2: String,
 }
 
-
-
 pub async fn get_shortest_path(
     query: web::Form<TwoActors>,
     movie_db: web::Data<MovieDB>,
@@ -34,7 +32,6 @@ pub async fn get_shortest_path(
         shortest_path(query.actor_1, query.actor_2, &movie_db),
     )
     .await;
-
 
     let path = match shortest_path_result {
         Ok(Ok(path)) => path,

--- a/static/index.html
+++ b/static/index.html
@@ -91,7 +91,7 @@
     <div>
         <div id="error-section" style="display: none;">
             <h2>Error</h2>
-            <p>Please select both a source and target actor.</p>
+            <p id="error-message">Please select both a source and target actor.</p>
         </div>
     </div>
 

--- a/static/index.js
+++ b/static/index.js
@@ -117,7 +117,7 @@ async function get_shortest_path(actor_1_id, actor_2_id) {
 
     const timeout = setTimeout(() => {
         controller.abort();
-    }, 25000);
+    }, 60000);
 
     try {
         const urlSearchParams = new URLSearchParams();
@@ -128,7 +128,7 @@ async function get_shortest_path(actor_1_id, actor_2_id) {
             method: 'POST',
             body: urlSearchParams,
             headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Type': 'application/x-www-form-urlencoded',
             },
             signal: signal
         });
@@ -145,10 +145,11 @@ async function get_shortest_path(actor_1_id, actor_2_id) {
         }
         return data;
 
+
     } catch (error) {
         clearTimeout(timeout);
         if (error.name === 'AbortError') {
-            throw new Error('Bro, this is taking too long. Please choose another pair.');
+            throw new Error('Timed out after 60s');
         }
         console.error(error);
         throw error;
@@ -223,7 +224,7 @@ submitButton.addEventListener('click', async () => {
         } catch (error) {
             console.error(error);
             spinner.classList.add('d-none');
-            error_message.textContent = 'Failed to fetch shortest path';
+            error_message.textContent = error.message;
             // Show the error section
             errorSection.style.display = 'block';
             // Hide the submission results
@@ -233,6 +234,8 @@ submitButton.addEventListener('click', async () => {
             isSubmitting = false;
         }
     } else {
+
+        error_message.textContent = 'Please select 2 actors';
         // Show the error section
         errorSection.style.display = 'block';
         // Hide the submission results

--- a/static/index.js
+++ b/static/index.js
@@ -105,6 +105,7 @@ actorInput2.addEventListener('keyup', async () => {
 // Get the submit button element
 const submitButton = document.getElementById('submit-button');
 const errorSection = document.getElementById('error-section');
+const error_message = document.getElementById('error-message');
 const submissionResultsList = document.getElementById('submission-results-list');
 const pathLengthHeader = document.getElementById('path-length-header');
 const resultsSection = document.getElementById('submission-results');
@@ -179,6 +180,10 @@ submitButton.addEventListener('click', async () => {
             spinner.classList.remove('d-none');
             resultsSection.style.display = 'none';
             let shortest_path_json = await get_shortest_path(actor_1, actor_2);
+            // if shortest path is error, throw it
+            if (shortest_path_json.error) {
+                throw new Error(shortest_path_json.error);
+            }
             spinner.classList.add('d-none');
             render_path(shortest_path_json);
             // Hide the error section
@@ -188,10 +193,12 @@ submitButton.addEventListener('click', async () => {
         } catch (error) {
             console.error(error);
             spinner.classList.add('d-none');
+            error_message.textContent = 'Failed to fetch shortest path';
             // Show the error section
             errorSection.style.display = 'block';
             // Hide the submission results
             resultsSection.style.display = 'none';
+
         }
     } else {
         // Show the error section

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28,25 +28,25 @@ mod test {
         let data_dir = PathBuf::from("data/new_large");
         make_db(&data_dir)
     }
-    #[test]
-    fn cruise_hanks() {
+    #[tokio::test]
+    async fn cruise_hanks() {
         let source_id: usize = 129;
         let target_id: usize = 158;
 
         let db = make_small_db();
 
-        let path = shortest_path(source_id, target_id, &db).unwrap();
+        let path = shortest_path(source_id, target_id, &db).await.unwrap();
         assert_eq!(path.len(), 3);
     }
-    #[test]
+    #[tokio::test]
     #[ignore = "takes too long"]
-    fn massey_fox() {
+    async fn massey_fox() {
         let source_id = 5368041;
         let target_id = 289114;
 
         let db = make_large_db();
 
-        let path = shortest_path(source_id, target_id, &db).unwrap();
+        let path = shortest_path(source_id, target_id, &db).await.unwrap();
         assert_eq!(path.len(), 8);
     }
 }


### PR DESCRIPTION
when requests take over 60s:
1. cancel the frontend fetch request
2. get the backend to return an error http

required us to make the shortest_distance() core function an async function. At every 1000 nodes explored, the function yields control back to the runtime. Allowing us to check if 60s has been passed since the function call. If so, the call is dropped and an http error is returned